### PR TITLE
Add --keep-colons opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ Examples:
 
 
 Options:
-  -u, --unPrefix   Un-prefix any property with vendor prefixes
-  -c, --cssSyntax  Keep CSS syntax punctuation
-  -f, --force      Overwrite existing .styl files
-  -i, --indent     Set indentation level
-  -o, --out        Specify an output directory
+  -u, --unPrefix     Un-prefix any property with vendor prefixes
+  -c, --cssSyntax    Keep CSS syntax punctuation
+  -f, --force        Overwrite existing .styl files
+  -i, --indent       Set indentation level
+  -o, --out          Specify an output directory
+  -:, --keep-colons  Keep colons: in rules
 ```
 
 Convert any css file:

--- a/bin/css2stylus
+++ b/bin/css2stylus
@@ -49,32 +49,31 @@ var yarg = require('yargs')
   .example('$0 -u -i 4 file1.css', 'Use 4 space ndent and convert file1.css while unprefixing.')
   .example('$0 -c file1.css file2.css', 'Preserve CSS syntax while converting multiple files.')
   .example('$0 file1.css -o styl', 'Save processed files files into the `styl` directoy')
-  .describe('u', 'Un-prefix any property with vendor prefixes.')
-  .alias('u', 'unPrefix')
-  .describe('c', 'Keep CSS syntax punctuation.')
-  .alias('c', 'cssSyntax')
-  .describe('f', 'Overwrite existing .styl files')
-  .alias('f', 'force')
-  .describe('i', 'Set indentation level')
-  .alias('i', 'indent')
-  .describe('o', 'Specify an output directory')
-  .alias('o', 'out');
+  .describe('unPrefix', 'Un-prefix any property with vendor prefixes.')
+    .alias('unPrefix', 'u')
+    .boolean('unPrefix')
+  .describe('cssSyntax', 'Keep CSS syntax punctuation.')
+    .alias('cssSyntax', 'c')
+    .boolean('cssSyntax')
+  .describe('force', 'Overwrite existing .styl files')
+    .alias('force', 'f')
+    .boolean('force')
+  .describe('indent', 'Set indentation level: «tab» or number (of spaces)')
+    .alias('indent', 'i')
+    .default('indent', 2)
+    .string('indent')
+  .describe('out', 'Specify an output directory')
+    .alias('out', 'o')
+    .string('out')
+  .describe('keepColons', 'Keep colons: in rules')
+    .alias('keepColons', ':')
+    .boolean('keepColons');
 
 var args = yarg.argv;
 
-var options = {};
+var options = args;
 var sdtdinData = '';
 var beganProcessingFiles = false;
-
-if (args.c) {
-  options.cssSyntax = true;
-}
-if (args.u) {
-  options.unPrefix = true;
-}
-if (args.i) {
-  options.indent = args.i;
-}
 
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', function (data) {

--- a/lib/css2stylus.js
+++ b/lib/css2stylus.js
@@ -54,7 +54,7 @@
       } else if (options.cssSyntax === false) {
         this.options.openingBracket = '';
         this.options.closingBracket = '';
-        this.options.semicolon = '';
+        this.options.semicolon = options.keepColons ? ':' : '';
         this.options.eol = '';
       }
 


### PR DESCRIPTION
Hi,

as i see, colons (`:`) is useful css retro syntax (which accepted by stylus)
and a lot of people use it in stylus (or only our team? oO)

Can i add option, which preserve/add colons to stylus output?

Thank you and excuse my beginner's English!

https://github.com/dciccale/css2stylus.js/issues/11