### PR TITLE
dont freeze on incorrect input file ext

### DIFF
--- a/bin/css2stylus
+++ b/bin/css2stylus
@@ -129,6 +129,7 @@ args._.forEach(function(file) {
       });
     });
   }
+  else throw new Error('Input file must be css!');
 });
 
 // bit hacky, but only way to tell if stdin hasn't been passed and no arguments were passed either


### PR DESCRIPTION
Fix minor bug: if input file is not styl, c2s simply freeze out