### PR TITLE
Make more tolerant to omitted semicolons;

### DIFF
--- a/lib/css2stylus.js
+++ b/lib/css2stylus.js
@@ -115,7 +115,7 @@
             }
           }
 
-          declaration.replace(/([^:;]+):(.+);$/mg, function (_declaration, property, value) {
+          declaration.replace(/([^:;]+):(.+)(;|$)$/mg, function (_declaration, property, value) {
             path.declarations.push({
               property: self.trim(property),
               value: self.trim(value)


### PR DESCRIPTION
if in css omitted `;`
e.g.: `.fsfd {foo: bar}`
c2s generates buggy stylus: `.fsfd`