### PR TITLE
fix freeze on error: stylusFile + ' already exists. Use -f to override.'

### DIFF
--- a/bin/css2stylus
+++ b/bin/css2stylus
@@ -107,7 +107,7 @@ args._.forEach(function(file) {
 
       if (!args.f && fs.existsSync(stylusFile)) {
         log.error(stylusFile + ' already exists. Use -f to override.');
-        return;
+        process.exit(1);
       }
 
       converter = new Css2Stylus.Converter(fileContents);


### PR DESCRIPTION
add aborting loop on another error.
